### PR TITLE
Prepare app for production

### DIFF
--- a/lib/kb_djornl/__init__.py
+++ b/lib/kb_djornl/__init__.py
@@ -21,7 +21,7 @@ from .utils import (
 
 
 def run_rwr_cv(config, clients):  # pylint: disable=too-many-locals
-    """ run RWR_CV and generate a report """
+    """run RWR_CV and generate a report"""
     params = config.get("params")
     shared = config.get("shared")
     dfu = clients["dfu"]
@@ -110,7 +110,7 @@ def run_rwr_cv(config, clients):  # pylint: disable=too-many-locals
 def run_rwr_loe(
     config, clients
 ):  # pylint: disable=too-many-locals, too-many-statements
-    """ run RWR_LOE and generate a report """
+    """run RWR_LOE and generate a report"""
     params = config.get("params")
     shared = config.get("shared")
     dfu = clients["dfu"]

--- a/lib/kb_djornl/utils.py
+++ b/lib/kb_djornl/utils.py
@@ -14,7 +14,7 @@ DATA_ROOT = os.environ.get("KBDJORNL_DATA_ROOT") or "/data/exascale_data/"
 def create_tair10_featureset(
     genes, config, dfu, gsu
 ):  # pylint: disable=too-many-locals
-    """ Create an Arabidopsis thaliana featureset from a list of genes. """
+    """Create an Arabidopsis thaliana featureset from a list of genes."""
     params = config.get("params")
     workspace_id = params["workspace_id"]
     genome_ref = "Phytozome_Genomes/Athaliana_TAIR10"
@@ -56,7 +56,7 @@ def create_tair10_featureset(
 
 
 def cytoscape_node(node, rank, seed=False):
-    """ convert nodedata into cytoscape format """
+    """convert nodedata into cytoscape format"""
     return dict(
         defline=node["defline"],
         geneSymbols=node["gene_symbols"],
@@ -71,7 +71,7 @@ def cytoscape_node(node, rank, seed=False):
 
 
 def cytoscape_edge(edge):
-    """ convert edge data into cytoscape format """
+    """convert edge data into cytoscape format"""
     return dict(
         id=edge["_id"],
         edgeType=edge["edge_type"],
@@ -170,12 +170,12 @@ def fork_rwr_loe(reports_path, params, dfu):  # pylint: disable=too-many-locals
 
 
 def genes_to_rwr_tsv(genes):
-    """ convert a list of genes to a tsv string for use with RWR tools"""
+    """convert a list of genes to a tsv string for use with RWR tools"""
     return "".join([f"report\t{gene}\n" for gene in genes])
 
 
 def get_wsurl():
-    """ Get the workspace url for this environment. """
+    """Get the workspace url for this environment."""
     config_file = os.environ.get("KB_DEPLOYMENT_CONFIG")
     config_p = configparser.ConfigParser()
     config_p.read(config_file)
@@ -183,14 +183,14 @@ def get_wsurl():
 
 
 def get_genes_from_tair10_featureset(featureset_ref, dfu):
-    """ Read genes from a A. thaliana featureset. """
+    """Read genes from a A. thaliana featureset."""
     featureset_response = dfu.get_objects({"object_refs": [featureset_ref]})
     featureset = featureset_response["data"][0]["data"]
     return featureset["element_ordering"]
 
 
 def load_manifest():
-    """ Load the manifest yaml file """
+    """Load the manifest yaml file"""
     manifest_path = os.path.join(DATA_ROOT, "prerelease/manifest.yaml")
     with open(manifest_path) as manifest_file:
         manifest = yaml.safe_load(manifest_file)
@@ -198,14 +198,14 @@ def load_manifest():
 
 
 def normalized_node_id(node_id):
-    """ normalize node id """
+    """normalize node id"""
     if "/" in node_id:
         return node_id.split("/")[1]
     return node_id
 
 
 def object_info_as_dict(object_info):
-    """ Convert a KBase object_info list into a dictionary. """
+    """Convert a KBase object_info list into a dictionary."""
     [
         _id,
         _name,
@@ -288,7 +288,7 @@ QUERY_NODE = """SELECT "GID" as node_id, *
 
 
 def query_sqlite(genes):  # pylint: disable=too-many-locals
-    """ Query the data loaded into sqlite3 based on seed genes """
+    """Query the data loaded into sqlite3 based on seed genes"""
     networks_path = os.path.join(DATA_ROOT, "networks.db")
     con = sqlite3.connect(networks_path)
     manifest = load_manifest()

--- a/scripts/postinstall.py
+++ b/scripts/postinstall.py
@@ -13,7 +13,7 @@ import requests
 
 
 def download_assets(assets, endpoint, cookies):
-    """Download assets from endpoint using cookies. """
+    """Download assets from endpoint using cookies."""
     destination_path = "test_local/workdir/tmp/reports"
     for asset in assets:
         asset_url = endpoint._replace(path=asset).geturl()

--- a/scripts/refdata-load.sh
+++ b/scripts/refdata-load.sh
@@ -6,7 +6,10 @@ set -e
 KB_ENV=$(grep -e kbase_endpoint /kb/module/work/config.properties \
     | cut -f3 -d'/' | cut -f1 -d. \
 )
-if [[ "$KB_ENV" == 'ci' ]]; then
+echo Detected environment $KB_ENV
+if [[ "$KB_ENV" == 'kbase' ]]; then
+    RWRTOOLS_BLOB_URL='https://kbase.us/services/shock-api/node/e27516d4-e54d-4931-91f7-7d36c25fe3cc?download_raw'
+elif [[ "$KB_ENV" == 'ci' ]]; then
     RWRTOOLS_BLOB_URL='https://ci.kbase.us/services/shock-api/node/0481bd3b-14b4-40f9-a585-aee531235edc?download_raw';
 elif [[ "$KB_ENV" == 'appdev' ]]; then
     RWRTOOLS_BLOB_URL='https://appdev.kbase.us/services/shock-api/node/29d12bac-53b9-451f-8fc6-48124f1c2f8f?download_raw';

--- a/scripts/rwrtools-env-create.sh
+++ b/scripts/rwrtools-env-create.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 source /miniconda/etc/profile.d/conda.sh
-conda env create -vv -f ./data/rwrtools.yml
+conda env create -v -f ./data/rwrtools.yml
 conda activate rwrtools
 R --no-restore --no-save << HEREDOC
 if (!requireNamespace("BiocManager", quietly = TRUE))

--- a/test/kb_djornl_server_test.py
+++ b/test/kb_djornl_server_test.py
@@ -24,14 +24,14 @@ from kb_djornl.authclient import KBaseAuth as _KBaseAuth
 
 
 def echo(*args, **kwargs):
-    """ echo arguments """
+    """echo arguments"""
     print(args)
     print(kwargs)
     return defaultdict(dict)
 
 
 class EchoMock:  # pylint: disable=too-few-public-methods
-    """ echo mocker """
+    """echo mocker"""
 
     def __getattribute__(self, name):
         assert name
@@ -39,20 +39,20 @@ class EchoMock:  # pylint: disable=too-few-public-methods
 
 
 class MockDFU:
-    """ mock dfu """
+    """mock dfu"""
 
     def save_objects(self, params):
-        """ mock dfu save_objects """
+        """mock dfu save_objects"""
         assert self, params
         return [[None] * 11]
 
     def ws_name_to_id(self, name):
-        """ mock workspace name to id """
+        """mock workspace name to id"""
         assert self
         return len(name)
 
     def get_objects(self, params):
-        """ mock get_objects """
+        """mock get_objects"""
         assert self
         ref = params["object_refs"][0]
         mock_filenames = dict(
@@ -67,7 +67,7 @@ class MockDFU:
 
 
 class kb_djornlTest(unittest.TestCase):  # pylint: disable=invalid-name
-    """ kb_djornl unit test class """
+    """kb_djornl unit test class"""
 
     @classmethod
     def setUpClass(cls):
@@ -129,12 +129,12 @@ class kb_djornlTest(unittest.TestCase):  # pylint: disable=invalid-name
             print("Test workspace was deleted")
 
     def setUp(self):
-        """ remove report dir before each test"""
+        """remove report dir before each test"""
         # the scratch dir is named shared in kb_djornlImpl
         shutil.rmtree(self.reports_path, ignore_errors=True)
 
     def _get_multiplex_params(self, multiplex):
-        """ Make parameters for RWR_CV and RWR_LOE mutliplex tests """
+        """Make parameters for RWR_CV and RWR_LOE mutliplex tests"""
         return {
             "workspace_id": self.workspace_id,
             "workspace_name": self.wsName,


### PR DESCRIPTION
This PR updates the refdata so that the app may be registered in appdev. When registered in appdev, the refdata is downloaded to production and then subsequently copied to appdev. Therefore when `refdata-load.sh` runs it is using a production token which means that the production blobstore instance must be used. The conda logs loglevel has been set to INFO from DEBUG to avoid errors in the registration process. A few docstrings were not formatted properly and black complained, so I have included that change in this PR as well.