### PR TITLE
Moved hyperlinks out of parameter description and into app and module…

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -2,7 +2,7 @@ module-name:
     kb_djornl
 
 module-description:
-    The RWRtools module enables Random Walk with Restart (RWR) on gene-to-gene multiplex networks from multiple lines of evidence. These include protein-protein interactions, metabolic reactions, transcription factor regulation, and gene co-expression. Descriptions of provided multiplexes can be found [here](https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md). RWRtools LOE (Lines of Evidence) performs RWR from one geneset to see how many of another geneset are highly ranked. RWRtools CV (Cross Validation) performs RWR Cross Validation on a single gene set to find the RWR rank of the left-out genes.
+    The RWRtools module enables Random Walk with Restart (RWR) on gene-to-gene multiplex networks from multiple lines of evidence. These include protein-protein interactions, metabolic reactions, transcription factor regulation, and gene co-expression. Descriptions of provided multiplexes can be found <a href="https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md">"here"</a>. RWRtools LOE (Lines of Evidence) performs RWR from one geneset to see how many of another geneset are highly ranked. RWRtools CV (Cross Validation) performs RWR Cross Validation on a single gene set to find the RWR rank of the left-out genes.
 
 service-language:
     python

--- a/kbase.yml
+++ b/kbase.yml
@@ -2,7 +2,7 @@ module-name:
     kb_djornl
 
 module-description:
-    The RWRtools module enables Random Walk with Restart (RWR) on gene-to-gene multiplex networks from multiple lines of evidence. These include protein-protein interactions, metabolic reactions, transcription factor regulation, and gene co-expression. RWRtools LOE (Lines of Evidence) performs RWR from one geneset to see how many of another geneset are highly ranked. RWRtools CV (Cross Validation) performs RWR Cross Validation on a single gene set to find the RWR rank of the left-out genes.
+    The RWRtools module enables Random Walk with Restart (RWR) on gene-to-gene multiplex networks from multiple lines of evidence. These include protein-protein interactions, metabolic reactions, transcription factor regulation, and gene co-expression. Descriptions of provided multiplexes can be found [here](https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md). RWRtools LOE (Lines of Evidence) performs RWR from one geneset to see how many of another geneset are highly ranked. RWRtools CV (Cross Validation) performs RWR Cross Validation on a single gene set to find the RWR rank of the left-out genes.
 
 service-language:
     python

--- a/ui/narrative/methods/run_rwr_cv/display.yaml
+++ b/ui/narrative/methods/run_rwr_cv/display.yaml
@@ -26,8 +26,8 @@ parameters :
         short-hint : |
             Choose a pre-built multiplex network based on types of experimental
                 evidence you would like incorporated in your analysis.  
-                Descriptions of multiplexes are located
-                <a href="https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md">"here"</a>.
+                Descriptions of multiplexes can be found by following the link 
+                in the app description. 
                 Default is the Comprehensive Network (9 network layers).
     node_rank_max:
         ui-name : |
@@ -79,4 +79,6 @@ description : |
         genes. Cross validation methods include <b>k-fold</b> (default method, k = 5),
         <b>leave-one-out (loo)</b> (leave only one gene from the gene set out 
         and use other genes to find its rank), or <b>singletons</b> (one 
-        gene is used to find the ranks of all other genes in the gene set).</p>
+        gene is used to find the ranks of all other genes in the gene set). 
+        Descriptions of provided multiplexes can be found 
+        [here](https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md).</p>

--- a/ui/narrative/methods/run_rwr_cv/display.yaml
+++ b/ui/narrative/methods/run_rwr_cv/display.yaml
@@ -81,4 +81,4 @@ description : |
         and use other genes to find its rank), or <b>singletons</b> (one 
         gene is used to find the ranks of all other genes in the gene set). 
         Descriptions of provided multiplexes can be found 
-        [here](https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md).</p>
+        <a href="https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md">"here"</a>.</p>

--- a/ui/narrative/methods/run_rwr_loe/display.yaml
+++ b/ui/narrative/methods/run_rwr_loe/display.yaml
@@ -4,7 +4,7 @@
 name: RWRtools LOE
 
 tooltip: |
-    RWR LOE (Lines of Evidence) uses RWR to rank genes in the network starting from a Feature Set.
+    RWRtools LOE (Lines of Evidence) uses RWR to rank genes in the network starting from a Feature Set.
 
 screenshots: []
 
@@ -31,8 +31,8 @@ parameters :
         short-hint : |
             Choose a pre-built multiplex network based on types of experimental
                 evidence you would like incorporated in your analysis.  
-                Descriptions of multiplexes are located
-                <a href="https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md">"here"</a>.
+                Descriptions of multiplexes can be found by following the 
+                link in the app description. 
                 Default is the Comprehensive Network (9 network layers).
     node_rank_max:
         ui-name : |
@@ -73,4 +73,5 @@ description : |
         returned. Given a second geneset of genes to be queried, rankings for just 
         the genes in that geneset will be returned. This can be used to build 
         multiple lines of evidence from the various input networks to relate the 
-        two gene sets.</p>
+        two gene sets. Descriptions of provided multiplexes can be found 
+        [here](https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md).</p>

--- a/ui/narrative/methods/run_rwr_loe/display.yaml
+++ b/ui/narrative/methods/run_rwr_loe/display.yaml
@@ -74,4 +74,4 @@ description : |
         the genes in that geneset will be returned. This can be used to build 
         multiple lines of evidence from the various input networks to relate the 
         two gene sets. Descriptions of provided multiplexes can be found 
-        [here](https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md).</p>
+        <a href="https://github.com/kbaseapps/kb_djornl/blob/main/NETWORKS.md">"here"</a>.</p>


### PR DESCRIPTION
In order to comply with KBase SDK standards, the hyperlinks in any parameter descriptions (for the multiplex dropdown) were moved to both the app and module descriptions. The parameter description for multiplexes was updated to point the user to that description field that should now correctly render the html link.