### PR TITLE
Updates for 2023 release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kbase/sdkbase2:python
+FROM kbase/sdkpython:3.8.0
 MAINTAINER KBase developer
 
 RUN apt-get update
@@ -7,19 +7,25 @@ RUN mkdir -p /kb/module/work
 WORKDIR /kb/module
 # Python and R requirements
 ENV PIP_PROGRESS_BAR=off
+ENV PATH=$PATH:/opt/conda3/bin
+RUN sh /opt/conda3/etc/profile.d/conda.sh
 RUN conda update -n base -c defaults conda
 COPY ./scripts/rwrtools-env-create.sh /kb/module/scripts/rwrtools-env-create.sh
 RUN ./scripts/rwrtools-env-create.sh
 COPY ./requirements.kb_sdk.txt /kb/module/requirements.kb_sdk.txt
+RUN conda install pip
 RUN pip install -r requirements.kb_sdk.txt
 COPY ./requirements.txt /kb/module/requirements.txt
 RUN pip install --extra-index-url https://pypi.anaconda.org/kbase/simple \
     -r requirements.txt
 # Node and node requirements
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh
+RUN chmod 500 nsolid_setup_deb.sh
+RUN ./nsolid_setup_deb.sh 20
 RUN apt-get install -y nodejs
 COPY ./package.json /kb/module/package.json
-RUN NO_POSTINSTALL=true npm install --production
+COPY ./scripts/postinstall.py /kb/module/scripts/postinstall.py
+RUN NO_POSTINSTALL=true npm install --omit=dev
 RUN npm install webpack-cli webpack
 COPY ./ /kb/module
 # fix permissions

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ refdata, see the [Howsto](#howsto) section below.
 
 # Contributing
 
-Note: By default the module image uses Python 3.7.0, and these instructions are
+Note: By default the module image uses Python 3.8.10, and these instructions are
 tested with this version, but will probably work with any higher version.
 Follow the following instructions to configure your development environment.
 
 0. Install prerequisites:
     - kb-sdk
-    - node >= 14.15.4
-    - python >= 3.7.0
+    - node >= 20.9.0
+    - python >= 3.8.10
 1. Make a virtual environment and activate it.
 ```
 python -m venv $VENV
@@ -126,7 +126,7 @@ This section specifically refers how to add, edit or replace edges in an
 2. Commit this change to the repository in GitHub.
 3. Modify the `git clone` command for `exascale_data` in
     `scripts/refdata-load.sh` to point to the correct branch or commit.
-4. Bump the `data-version` semantic version value in `kbase.yaml`. This will
+4. Bump the `data-version` semantic version value in `kbase.yml`. This will
     ensure that the refdata is loaded in the next step.
 5. Commit these changes to the `kb_djornl` repository in GitHub.
 6. Test this new version of the app.
@@ -155,7 +155,7 @@ header row. It also assumes that this network introduces a single new
     2. Modify the `git clone` command for `exascale_data` and `relation_engine`
         in `scripts/refdata-load.sh` to point to the correct branch or commit
         for the changes above.
-    3. Bump the `data-version` semantic version value in `kbase.yaml`. This
+    3. Bump the `data-version` semantic version value in `kbase.yml`. This
         will ensure that the refdata is loaded in the next step.
     4. Commit these changes to the repository in GitHub.
 4. Test this new version of the app.

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,10 +8,10 @@ service-language:
     python
 
 module-version:
-    0.0.2
+    1.0.0
 
 owners:
     [dakota]
 
 data-version:
-    0.0.9
+    1.0.0

--- a/lib/kb_djornl/__init__.py
+++ b/lib/kb_djornl/__init__.py
@@ -82,8 +82,9 @@ def run_rwr_cv(config, clients):  # pylint: disable=too-many-locals
 
     def artifact_path(artifact):
         """Return metrics and summary output file path."""
+        multiplex_name = multiplex.replace(".RData", "")
         return os.path.join(
-            reports_path, f"data/RWR-CV__report_{multiplex}_default.{artifact}.tsv"
+            reports_path, f"data/RWR-CV__report_{multiplex_name}_default.{artifact}.tsv"
         )
 
     # create report object

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-PyYAML==5.4.1
+PyYAML==6.0.1
 black==20.8b1
-pandas==1.1.5
+pandas==2.0.3
 pylint==2.6.0
 releng-client==0.0.1

--- a/scripts/rwrtools-env-create.sh
+++ b/scripts/rwrtools-env-create.sh
@@ -3,8 +3,8 @@
 set -x
 set -e
 
-source /miniconda/etc/profile.d/conda.sh
-conda create -v -n rwrtools -c conda-forge r-base=4.0.2 r-devtools
+source /opt/conda3/etc/profile.d/conda.sh
+conda create -v -n rwrtools -c conda-forge r-base=4.1.0 r-devtools
 conda activate rwrtools
 git clone https://github.com/dkainer/RWRtoolkit.git
 cd RWRtoolkit

--- a/scripts/rwrtools-run.sh
+++ b/scripts/rwrtools-run.sh
@@ -6,7 +6,7 @@ set -x
 export RWR_TOOLS_REPO=${RWR_TOOLS_REPO:-'/kb/module/RWRtools/'}
 set +x
 echo Activate rwrtools conda environment
-source /miniconda/etc/profile.d/conda.sh
+source /opt/conda3/etc/profile.d/conda.sh
 conda activate rwrtools
 set -x
 mkdir -p /opt/work/tmp


### PR DESCRIPTION
Some of these updates are directly a consequence of using the new base image, but are mentioned here as they make a difference in this module specifically.

Updated dependency versions:

- node v20.9.0
- python 3.8.10
- R 4.1.0

Changes
- Debian 9 Stretch to Ubuntu 20.04.6
- miniconda to mamba, conda 4.11.0.