### PR TITLE
Updated to work with RWRtoolkit updates.

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,10 +8,10 @@ service-language:
     python
 
 module-version:
-    1.0.1
+    1.0.2
 
 owners:
     [dakota]
 
 data-version:
-    1.0.0
+    1.0.2

--- a/lib/kb_djornl/__init__.py
+++ b/lib/kb_djornl/__init__.py
@@ -40,7 +40,7 @@ def run_rwr_cv(config, clients):  # pylint: disable=too-many-locals
     # Run RWR_CV with the given parameters
     gene_keys, cv_folds = fork_rwr_cv(reports_path, params, dfu)
     fullranks_path = os.path.join(reports_path, "data/fullranks.tsv")
-    medianranks_path = os.path.join(reports_path, "data/medianranks.tsv")
+    meanranks_path = os.path.join(reports_path, "data/meanranks.tsv")
     shutil.copytree(
         "/opt/work/tmp/",
         os.path.join(reports_path, "data"),
@@ -100,9 +100,9 @@ def run_rwr_cv(config, clients):  # pylint: disable=too-many-locals
             "path": fullranks_path,
         },
         {
-            "description": "medianranks",
-            "name": "medianranks.tsv",
-            "path": medianranks_path,
+            "description": "meanranks",
+            "name": "meanranks.tsv",
+            "path": meanranks_path,
         },
         {
             "description": "metrics",

--- a/lib/kb_djornl/utils.py
+++ b/lib/kb_djornl/utils.py
@@ -115,7 +115,7 @@ def fork_rwr_cv(reports_path, params, dfu):
                 --numranked='1'
                 --outdir='/opt/work/tmp'
                 --out-fullranks='/opt/work/tmp/fullranks.tsv'
-                --out-medianranks='/opt/work/tmp/medianranks.tsv'
+                --out-meanranks='/opt/work/tmp/meanranks.tsv'
                 --verbose
     """
     subprocess.run(

--- a/scripts/refdata-load.sh
+++ b/scripts/refdata-load.sh
@@ -21,5 +21,8 @@ test -f /data/exascale_data/networks.db && rm /data/exascale/networks.db
 /kb/module/scripts/networks_load.py
 # Retrieve RWR tools and data
 git clone https://github.com/dkainer/RWRtoolkit.git /data/RWRtools
+cd /data/RWRtools
+# see also rwrtools-env-create.sh
+git reset --hard 360f33794f7d81c254b7d8d16ef7649d0412f790
 git clone https://github.com/dkainer/RWRtoolkit-data.git /data/RWRtools/multiplexes
 touch /data/__READY__

--- a/scripts/rwrtools-env-create.sh
+++ b/scripts/rwrtools-env-create.sh
@@ -8,6 +8,8 @@ conda create -v -n rwrtools -c conda-forge r-base=4.1.0 r-devtools
 conda activate rwrtools
 git clone https://github.com/dkainer/RWRtoolkit.git
 cd RWRtoolkit
+# see also refdata-load.sh
+git reset --hard 360f33794f7d81c254b7d8d16ef7649d0412f790
 R --no-restore --no-save << HEREDOC
 devtools::install()
 HEREDOC

--- a/test/data/cv_seeds.ci.json
+++ b/test/data/cv_seeds.ci.json
@@ -1,28 +1,42 @@
 {
-    "data": [
-        {
-            "data": {
-                "description": "",
-                "element_ordering": ["ATCG00280", "AT1G01100", "AT1G18590"],
-                "elements": {
-                    "AT1G01100": ["6976/1042/4"],
-                    "AT1G18590": ["6976/1042/4"],
-                    "ATCG00280": ["6976/1042/4"]
-                }
-            },
-            "info": [
-                138,
-                "CVSeeds",
-                "KBaseCollections.FeatureSet-4.0",
-                "2021-10-08T20:05:45+0000",
-                1,
-                "dakota_ci",
-                59690,
-                "dakota_ci:narrative_1613146930948",
-                "7d6039c242f8aa1c8cfcb722a0947941",
-                172,
-                {}
-            ]
+  "data": [
+    {
+      "data": {
+        "description": "",
+        "element_ordering": [
+          "ATCG00280",
+          "AT1G01100",
+          "AT1G18590",
+          "AT4G25420"
+        ],
+        "elements": {
+          "AT1G01100": [
+            "6976/1042/4"
+          ],
+          "AT1G18590": [
+            "6976/1042/4"
+          ],
+          "ATCG00280": [
+            "6976/1042/4"
+          ],
+          "AT4G25420": [
+            "6976/1042/4"
+          ]
         }
-    ]
+      },
+      "info": [
+        138,
+        "CVSeeds",
+        "KBaseCollections.FeatureSet-4.0",
+        "2021-10-08T20:05:45+0000",
+        1,
+        "dakota_ci",
+        59690,
+        "dakota_ci:narrative_1613146930948",
+        "7d6039c242f8aa1c8cfcb722a0947941",
+        172,
+        {}
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This PR brings RWRtoolkit up to the latest version. The `out-medianranks` flag changed to `out-meanranks` and that has been updated. The new version also exposed an issue with a module test which was attempting cross validation on a set of one item which is not, strictly speaking, possible, so the test has been updated and fixed. The module now specifies which version of RWRtoolkit is being used, so that any future updates can be migrated to on a timeline of our choice.