### PR TITLE
Pin outdated R dependencies MASS and Matrix.

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -52,7 +52,7 @@ jobs:
         # Add token to config
         sed -ie "s/^test_token=.*$/&$KBASE_TEST_TOKEN/g" ./test_local/test.cfg
         # Configure to use CI environment
-        sed -ie "s/appdev/ci/g" ./test_local/test.cfg
+        # sed -ie "s/appdev/ci/g" ./test_local/test.cfg
 
     - name: Run tests
       if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/scripts/rwrtools-env-create.sh
+++ b/scripts/rwrtools-env-create.sh
@@ -13,6 +13,8 @@ cd RWRtoolkit
 git reset --hard 360f33794f7d81c254b7d8d16ef7649d0412f790
 R --no-restore --no-save << HEREDOC
 require(devtools)
+install_version("Matrix", version = "1.6-5", repos = "http://cran.us.r-project.org")
+install_version("MASS", version = "7.3-60.0.1", repos = "http://cran.us.r-project.org")
 install_version("igraph", version = "1.6.0", repos = "http://cran.us.r-project.org")
 install_version("supraHex", version = "1.32.0", repos = "https://bioconductor.org/packages/3.14/bioc")
 install_version("dnet", version = "1.1.7", repos = "http://cran.us.r-project.org")


### PR DESCRIPTION
This commit also switches back to the appdev testing environment. This change means that the `KBASE_TEST_TOKEN` organization secret can be used as is. Therefore the tests should continue to run successfully even though these tokens expire in 90 days since DEVOPS already refreshes these secrets periodically.