### PR TITLE
Updated dependencies to use URLs directly.

### DIFF
--- a/scripts/rwrtools-env-create.sh
+++ b/scripts/rwrtools-env-create.sh
@@ -13,11 +13,11 @@ cd RWRtoolkit
 git reset --hard 360f33794f7d81c254b7d8d16ef7649d0412f790
 R --no-restore --no-save << HEREDOC
 require(devtools)
-install_version("Matrix", version = "1.6-5", repos = "http://cran.us.r-project.org")
-install_version("MASS", version = "7.3-60.0.1", repos = "http://cran.us.r-project.org")
-install_version("igraph", version = "1.6.0", repos = "http://cran.us.r-project.org")
-install_version("supraHex", version = "1.32.0", repos = "https://bioconductor.org/packages/3.14/bioc")
-install_version("dnet", version = "1.1.7", repos = "http://cran.us.r-project.org")
+install_url("https://cran.r-project.org/src/contrib/Archive/Matrix/Matrix_1.6-5.tar.gz")
+install_url("https://cran.r-project.org/src/contrib/Archive/MASS/MASS_7.3-60.0.1.tar.gz")
+install_url("https://cran.r-project.org/src/contrib/Archive/igraph/igraph_1.6.0.tar.gz")
+install_url("https://bioconductor.org/packages/3.14/bioc/src/contrib/supraHex_1.32.0.tar.gz")
+install_url("https://cran.r-project.org/src/contrib/Archive/dnet/dnet_1.1.7.tar.gz")
 devtools::install()
 
 HEREDOC


### PR DESCRIPTION
Some CRAN updates seem to have broken our usage of `remotes::install_version`, so we can use `remotes::install_url` instead.