### PR TITLE
Update to use the patch branch of kb_sdk_actions.

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -25,6 +25,7 @@ jobs:
       if: "!contains(github.event.head_commit.message, 'skip ci')"
       uses: actions/checkout@v2
       with:
+        ref: 'patch'
         repository: 'kbaseapps/kb_sdk_actions'
         path: 'kb_sdk_actions'
 

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -40,10 +40,6 @@ jobs:
         test -f "$GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk" && echo "CI files cloned"
         # Pull kb-sdk & create startup script
         docker pull ghcr.io/kbase/kb_sdk_patch-develop:br-main
-        sed -ie "s/kbase\/kb-sdk/ghcr.io\/kbase\/kb_sdk_patch-develop:br-0.0.4/" \
-          "$GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk"
-        sed -ie "s/kbase\/kb-sdk/ghcr.io\/kbase\/kb_sdk_patch-develop:br-0.0.4/" \
-          "$GITHUB_WORKSPACE/kb_sdk_actions/bin/make_testdir"
         sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/make_testdir && echo "Created test_local"
         test -f "test_local/test.cfg" && echo "Confirmed config exists"
 


### PR DESCRIPTION
This PR adjusts the GitHub `kb_sdk test` action, in `action.yaml`, to use the `kb_sdk_patch` image. The `action.yaml` file is also aligned with the `patch` branch of `kb_sdk_actions` which provides a model of how to opt in to the new patch, specifically by adding `ref: 'patch'` in `action.yaml`.

If the `kb_sdk_patch` image becomes trusted enough to replace [`kbase/kb_sdk:1.2.1`](https://hub.docker.com/layers/kbase/kb-sdk/1.2.1/images/sha256-0d390445e69ef8611853d5d367cd48c354ad98464b53be933b4e2fd662e669a5?context=explore) (a.k.a. `kbase/kb_sdk:latest`, the one installed if you follow the [KBase SDK Documentation installation instructions](https://kbase.github.io/kb_sdk_docs/tutorial/2_install.html#installation)) then the `patch` branch of `kb_sdk_actions` can be merged and any module using those actions will automagically start using the new patched image.